### PR TITLE
LPD-93598 Wrong page name for guardrails

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
@@ -140,6 +140,7 @@ public class AIHubSiteInitializerTest {
 			"L_AI_HUB_AGENT_DEFINITION", "L_AI_HUB_AGENT_ADMINISTRATOR",
 			"ADD_OBJECT_ENTRY");
 		_assertLayoutExists("/account-management");
+		_assertLayoutExists("/guardrails");
 		_assertLayoutUtilityPageEntryExists(
 			"L_AI_HUB_CREATE_ACCOUNT_UTILITY_PAGE",
 			LayoutUtilityPageEntryConstants.TYPE_CREATE_ACCOUNT);

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/09_model-armor-template/page.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/layouts/09_model-armor-template/page.json
@@ -1,5 +1,5 @@
 {
-	"friendlyURL": "/model-armor-template",
+	"friendlyURL": "/guardrails",
 	"hidden": true,
 	"name_i18n": {
 		"en_US": "Model Armor Template"

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/ViewModelArmorTemplatesDisplayContext.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/ViewModelArmorTemplatesDisplayContext.java
@@ -41,7 +41,7 @@ public class ViewModelArmorTemplatesDisplayContext {
 			dropdownItem -> {
 				dropdownItem.setHref(
 					DisplayContextUtil.getAIHubURL(_themeDisplay) +
-						"/model-armor-template");
+						"/guardrails");
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "new-guardrail"));
 			}
@@ -55,7 +55,7 @@ public class ViewModelArmorTemplatesDisplayContext {
 			new FDSActionDropdownItem(
 				StringBundler.concat(
 					DisplayContextUtil.getAIHubURL(_themeDisplay),
-					"/model-armor-template",
+					"/guardrails",
 					"?externalReferenceCode={externalReferenceCode}"),
 				"view", "view", LanguageUtil.get(_httpServletRequest, "view"),
 				"get", null, null),

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/test/java/com/liferay/ai/hub/web/internal/display/context/ViewModelArmorTemplatesDisplayContextTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/test/java/com/liferay/ai/hub/web/internal/display/context/ViewModelArmorTemplatesDisplayContextTest.java
@@ -1,0 +1,127 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.web.internal.display.context;
+
+import com.liferay.ai.hub.web.internal.test.util.DisplayContextTestUtil;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author João Victor Alves
+ */
+public class ViewModelArmorTemplatesDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_setUpLanguageUtil();
+
+		HttpServletRequest httpServletRequest =
+			DisplayContextTestUtil.setUpHttpServletRequest();
+
+		DisplayContextTestUtil.setUpThemeDisplay(
+			Mockito.mock(Company.class), Mockito.mock(Group.class),
+			httpServletRequest);
+
+		_viewModelArmorTemplatesDisplayContext =
+			new ViewModelArmorTemplatesDisplayContext(httpServletRequest);
+	}
+
+	@Test
+	public void testGetCreationMenu() throws Exception {
+		CreationMenu creationMenu =
+			_viewModelArmorTemplatesDisplayContext.getCreationMenu();
+
+		List<DropdownItem> dropdownItems = (List<DropdownItem>)creationMenu.get(
+			"primaryItems");
+
+		Assert.assertEquals(dropdownItems.toString(), 1, dropdownItems.size());
+
+		DropdownItem dropdownItem = dropdownItems.get(0);
+
+		Assert.assertEquals(
+			"http://localhost:8080/web/test/guardrails",
+			dropdownItem.get("href"));
+		Assert.assertEquals("new-guardrail", dropdownItem.get("label"));
+	}
+
+	@Test
+	public void testGetFDSActionDropdownItems() throws Exception {
+		List<FDSActionDropdownItem> fdsActionDropdownItems =
+			_viewModelArmorTemplatesDisplayContext.getFDSActionDropdownItems();
+
+		Assert.assertEquals(
+			fdsActionDropdownItems.toString(), 2,
+			fdsActionDropdownItems.size());
+
+		_assertFDSActionDropdownItem(
+			fdsActionDropdownItems.get(0),
+			"http://localhost:8080/web/test/guardrails" +
+				"?externalReferenceCode={externalReferenceCode}",
+			"view", "view", "view", "get", null);
+		_assertFDSActionDropdownItem(
+			fdsActionDropdownItems.get(1),
+			"/o/ai-hub/v1.0/model-armor-templates/by-external-reference-code" +
+				"/{externalReferenceCode}",
+			"trash", "delete", "delete", "delete", "async");
+	}
+
+	private void _assertFDSActionDropdownItem(
+		FDSActionDropdownItem fdsActionDropdownItem, String href, String icon,
+		String id, String label, String method, String target) {
+
+		Map<String, String> data =
+			(Map<String, String>)fdsActionDropdownItem.get("data");
+
+		Assert.assertEquals(id, data.get("id"));
+		Assert.assertEquals(method, data.get("method"));
+
+		Assert.assertEquals(href, fdsActionDropdownItem.get("href"));
+		Assert.assertEquals(icon, fdsActionDropdownItem.get("icon"));
+		Assert.assertEquals(label, fdsActionDropdownItem.get("label"));
+		Assert.assertEquals(target, fdsActionDropdownItem.get("target"));
+	}
+
+	private void _setUpLanguageUtil() {
+		LanguageUtil languageUtil = new LanguageUtil();
+
+		languageUtil.setLanguage(Mockito.mock(Language.class));
+
+		Mockito.when(
+			LanguageUtil.get(
+				Mockito.any(HttpServletRequest.class), Mockito.anyString())
+		).thenAnswer(
+			invocation -> invocation.getArgument(1)
+		);
+	}
+
+	private ViewModelArmorTemplatesDisplayContext
+		_viewModelArmorTemplatesDisplayContext;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93598

## What Is Being Fixed

In the AI Hub UI, creating or viewing a guardrail navigated to `/web/ai-hub/model-armor-template`. The browser URL exposed the internal "model-armor-template" object name instead of "guardrails", the user-facing term the rest of the UI already uses (the page title, the "New guardrail" button, and all labels).

## How It Is Being Fixed

The guardrails layout friendly URL in the AI Hub site initializer was renamed from `/model-armor-template` to `/guardrails`, and the navigation links in `ViewModelArmorTemplatesDisplayContext` (the creation menu and the row "View" action) were updated to point at the new path. The internal REST API path (`/o/ai-hub/model-armor-templates`) is left unchanged because it is not user-facing.

Coverage was added at both layers the change touches: `AIHubSiteInitializerTest` now asserts the layout resolves at `/guardrails`, and the new `ViewModelArmorTemplatesDisplayContextTest` asserts the creation menu and row actions resolve to that URL.

## PR Check

**pr-check: SKIPPED** — Structural Smoke failed only on pre-existing baseline drift in the local checkout (`Log4jConfigUtilTest` Whip coverage and `LibraryReferenceTest` missing `spring-instrument-tomcat.jar` references), both unrelated to this ai-hub-only diff. The four relevant validations — Source Format, Integration Test Compile, Per-Module Deploy, Java Unit Tests — all passed on `06c2d9f7`.

<!-- pr-check {"reason": "Structural Smoke failed only on pre-existing local-checkout baseline drift (Log4jConfigUtilTest Whip coverage, LibraryReferenceTest missing spring-instrument-tomcat.jar references), unrelated to this ai-hub-only diff; Source Format, Integration Test Compile, Per-Module Deploy, and Java Unit Tests all passed.", "result": "skipped", "sha": "06c2d9f7c461f1afb8784d4bf91d1dab00989a11"} -->